### PR TITLE
fix: fails to create annotated tag if no tty is present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 FROM alpine:3.18
 
 RUN apk add --no-cache git git-lfs gnupg tini curl
-RUN sh -c "$(curl https://raw.githubusercontent.com/purpleclay/gpg-import/main/scripts/install)"
+RUN sh -c "$(curl https://raw.githubusercontent.com/purpleclay/gpg-import/main/scripts/install)" -- -v 0.3.2
 
 ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]
 CMD ["--help"]


### PR DESCRIPTION
closes #43 