### PR TITLE
fix: use the base directory when calculating the tag prefix when run outside of the root git directory

### DIFF
--- a/internal/nsv/semver.go
+++ b/internal/nsv/semver.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -82,7 +83,10 @@ func execContext(gitc *git.Client) (*context, error) {
 		logPath = git.RelativeAtRoot
 	}
 
-	return &context{TagPrefix: relPath, LogPath: logPath}, nil
+	return &context{
+		TagPrefix: filepath.Base(relPath),
+		LogPath:   logPath,
+	}, nil
 }
 
 type Tag struct {

--- a/internal/nsv/semver_test.go
+++ b/internal/nsv/semver_test.go
@@ -112,13 +112,13 @@ nsv:force~major
 
 func TestNextVersionIncludesSubDirectoryAsPrefix(t *testing.T) {
 	log := `feat(trends)!: breaking change to capturing user trends`
-	gittest.InitRepository(t, gittest.WithLog(log), gittest.WithFiles("search/main.go", "store/main.go"))
-	gittest.StageFile(t, "search/main.go")
+	gittest.InitRepository(t, gittest.WithLog(log), gittest.WithFiles("src/search/main.go", "src/store/main.go"))
+	gittest.StageFile(t, "src/search/main.go")
 	gittest.Commit(t, "feat(search): add support to search across user trends for recommendations")
-	gittest.StageFile(t, "store/main.go")
+	gittest.StageFile(t, "src/store/main.go")
 	gittest.Commit(t, "fix(store): fixed timestamp formatting issues")
 
-	os.Chdir("search")
+	os.Chdir("src/search")
 	gitc, _ := git.NewClient()
 
 	next, err := nsv.NextVersion(gitc, nsv.Options{})


### PR DESCRIPTION
closes #64 