### PR TITLE
fix: ensure tag format is respected when searching the log for the latest version

### DIFF
--- a/docs/next-version.md
+++ b/docs/next-version.md
@@ -59,7 +59,7 @@ ui/0.2.1,search/0.3.0
 
 ## Version template customization
 
-Internally `nsv` utilizes a go template when constructing the next semantic version:
+Internally, `nsv` utilizes a go template when constructing the next semantic version:
 
 ```{ .sh .no-select }
 {{.Prefix}}{{.Version}}
@@ -78,3 +78,20 @@ Runtime customization of this template is available. For example, you can enforc
     ```{ .sh .no-select }
     nsv next --format "{{.SemVer}}"
     ```
+Or you could enforce a prefix on all of your tags:
+
+=== "ENV"
+
+    ```{ .sh .no-select }
+    NSV_FORMAT="ui/{{.SemVer}}" nsv next
+    ```
+
+=== "CLI"
+
+    ```{ .sh .no-select }
+    nsv next --format "ui/{{.SemVer}}"
+    ```
+
+!!! tip "Tag prefixes are used by nsv when scanning for previous versions"
+
+    This is incredibly helpful if you want to maintain multiple tags within a monorepo, as each tag will be versioned independently.

--- a/internal/nsv/semver.go
+++ b/internal/nsv/semver.go
@@ -73,8 +73,17 @@ func resolveContext(gitc *git.Client, opts Options) (*gitContext, error) {
 		}
 	}
 
+	var tagPrefix string
+	if opts.VersionFormat != "" {
+		if idx := strings.LastIndex(opts.VersionFormat, "/"); idx != -1 {
+			opts.Logger.Debug("custom tag format includes prefix")
+			tagPrefix = opts.VersionFormat[:idx-1]
+		}
+	}
+
 	if relPath == git.RelativeAtRoot {
-		return &gitContext{TagPrefix: "", LogPath: relPath}, nil
+		opts.Logger.Debug("resolved git context", "tag_prefix", tagPrefix, "log_path", relPath)
+		return &gitContext{TagPrefix: tagPrefix, LogPath: relPath}, nil
 	}
 
 	logPath := relPath
@@ -82,7 +91,9 @@ func resolveContext(gitc *git.Client, opts Options) (*gitContext, error) {
 		logPath = git.RelativeAtRoot
 	}
 
-	tagPrefix := filepath.Base(relPath)
+	if tagPrefix == "" {
+		tagPrefix = filepath.Base(relPath)
+	}
 
 	opts.Logger.Debug("resolved git context", "tag_prefix", tagPrefix, "log_path", logPath)
 	return &gitContext{

--- a/internal/nsv/semver_test.go
+++ b/internal/nsv/semver_test.go
@@ -235,6 +235,23 @@ func TestNextVersionWithFormat(t *testing.T) {
 	assert.Equal(t, "custom/v0.1.0", next.Tag)
 }
 
+func TestNextVersionResolvesTagUsingFormat(t *testing.T) {
+	log := `(main) feat: extend existing helm chart to deploy ui
+feat: add a ui for easy searching and management of data
+(tag: search/0.1.1) fix: search filters were not being applied in correct order
+(tag: search/0.1.0) feat: extend search through customizable filters`
+	format := "ui/{{ .Version }}"
+
+	gittest.InitRepository(t, gittest.WithLog(log))
+	gitc, _ := git.NewClient()
+
+	next, err := nsv.NextVersion(gitc, nsv.Options{VersionFormat: format, Logger: noopLogger})
+
+	require.NoError(t, err)
+	require.NotNil(t, next)
+	assert.Equal(t, "ui/0.1.0", next.Tag)
+}
+
 func TestNextVersionWithHook(t *testing.T) {
 	log := `> (main, origin/main) feat: support patching files using a hook
 > (tag: 0.1.0) feat: ensure diffs can be displayed in the summary`


### PR DESCRIPTION
closes #226 